### PR TITLE
fix: don't copy node_module/ into docker container

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,8 @@ COPY package-lock.json ./
 # RUN npm ci
 RUN npm ci
 
-COPY . ./
+COPY src ./
+COPY public ./
 
 # start app
 CMD ["npm", "start"]


### PR DESCRIPTION
Fix don't copy node_module/ into docker container.